### PR TITLE
Process manager finite state machine macro

### DIFF
--- a/lib/support/fsm_process_manager.ex
+++ b/lib/support/fsm_process_manager.ex
@@ -1,0 +1,27 @@
+defmodule FsmProcessManager do
+  defmacro __using__(opts) do
+    quote do
+      import Kernel, except: [apply: 2]
+
+      use Fsm, initial_state: unquote(opts[:initial_state])
+
+      def handle(%__MODULE__{state: nil} = fsm, event), do: __MODULE__.handle(__MODULE__.new, event)
+      def handle(%__MODULE__{} = fsm, event) do
+        fsm
+        |> __MODULE__.on(event)
+        |> __MODULE__.data  # commands extracted from the FSM's data
+      end
+
+      def apply(%__MODULE__{state: nil} = fsm, event), do: __MODULE__.apply(__MODULE__.new, event)
+      def apply(%__MODULE__{} = fsm, event) do
+        state =
+          fsm
+          |> __MODULE__.on(event)
+          |> __MODULE__.state
+
+        # extract and return just the FSM's state
+        %__MODULE__{state: state}
+      end
+    end
+  end
+end

--- a/test/registration_process_manager_test.exs
+++ b/test/registration_process_manager_test.exs
@@ -1,0 +1,21 @@
+defmodule EvSim.RegistrationProcessManagerTest do
+  use ExUnit.Case
+
+  alias EvSim.Order.Events.{OrderPlaced}
+
+  describe "not started" do
+    test "should make seat reservation when order placed" do
+      commands = EvSim.ProcessManager.Manager.handle(%EvSim.ProcessManager.Manager{}, %OrderPlaced{uuid: "1234"})
+
+      assert commands == [
+        %EvSim.Conference.Commands.MakeSeatReservation{uuid: "1234"}
+      ]
+    end
+
+    test "should transition state to awaiting reservation when order placed" do
+      state = EvSim.ProcessManager.Manager.apply(%EvSim.ProcessManager.Manager{}, %OrderPlaced{uuid: "1234"})
+
+      assert state == %EvSim.ProcessManager.Manager{state: :awaiting_reservation}
+    end
+  end
+end


### PR DESCRIPTION
To support integration with Commanded.

A quick macro to allow the FSM library to be used with Commanded's process manager API. I renamed the FSM events to `on` to avoid clashing with the `handle` function called by Commanded. There are two unit tests to demo it working.

Using the `FsmProcessManager` macro would allow you to define the commands and transitions as an FSM and be hosted by Commanded. 

At the moment Commanded sets the initial process manager state by calling `struct(YourProcessManagerModule)`. Whereas the FSM library wants you to use `YourFSM.new`. I could change Commanded to either call `.new` or allow you to specify how to construct the initial state.